### PR TITLE
Replace deprecated failure with anyhow and thiserror crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arrayref"
@@ -937,17 +937,18 @@ dependencies = [
 name = "reddb"
 version = "0.2.3"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64",
  "bincode",
  "cargo-husky",
- "failure",
  "futures",
  "grcov",
  "ron",
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
  "tokio 0.2.24",
  "tokio-test",
  "uuid",
@@ -1244,18 +1245,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ path = "src/lib.rs"
 
 [dependencies]
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-failure = "0.1.8"
+anyhow = "1.0.38"
+thiserror = "1.0.24"
 tokio = { version = "0.2", features = ["macros","fs","stream","sync","rt-util"] }
 serde = { version = "1.0", features = ["derive"] }
 futures = "0.3.8"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,82 +1,66 @@
-use failure::{Backtrace, Context, Fail};
+use thiserror::Error;
 use std::fmt::{self, Display};
 use uuid::Uuid;
 
-pub type Result<T> = ::std::result::Result<T, RedDbError>;
+pub type Result<T> = ::anyhow::Result<T, RedDbError>;
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Error)]
 pub enum RedDbErrorKind {
     //STORAGE
-    #[fail(display = "Data corrupted!")]
+    #[error("Data corrupted!")]
     DataCorruption,
-    #[fail(display = "Data compacted corrupted!")]
+    #[error("Data compacted corrupted!")]
     Compact,
-    #[fail(display = "Could not compact storage")]
+    #[error("Could not compact storage")]
     Storagepersist,
-    #[fail(display = "Could not flush data into storage")]
+    #[error("Could not flush data into storage")]
     FlushData,
-    #[fail(display = "Could not flush data")]
+    #[error("Could not flush data")]
     AppendData,
-    #[fail(display = "Could not append data ")]
+    #[error("Could not append data ")]
     StorageInit,
-    #[fail(display = "Could not init storage")]
+    #[error("Could not init storage")]
     StorageData,
-    #[fail(display = "Could not read storage data")]
+    #[error("Could not read storage data")]
     ReadContent,
-    #[fail(display = "Could not load storage content")]
+    #[error("Could not load storage content")]
     ContentLoad,
-    #[fail(display = "Could not persist data into storage")]
+    #[error("Could not persist data into storage")]
     Datapersist,
     // uuids
-    #[fail(display = "Could not find _id {}", _id)]
+    #[error("Could not find _id {_id}")]
     NotFound { _id: Uuid },
-    #[fail(display = "Could not delete _id")]
+    #[error("Could not delete _id")]
     Deletekey,
-    #[fail(display = "Could not unlock mutex")]
+    #[error("Could not unlock mutex")]
     Mutex,
-    #[fail(display = "Database poisoned!")]
+    #[error("Database poisoned!")]
     Poisoned,
-    #[fail(display = "data poisoned!")]
+    #[error("data poisoned!")]
     PoisonedValue,
     // SERDE
-    #[fail(display = "Could not deserialize data")]
+    #[error("Could not deserialize data")]
     Deserialization,
-    #[fail(display = "Could not serialize data")]
+    #[error("Could not serialize data")]
     Serialization,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub struct RedDbError {
-    err: Context<RedDbErrorKind>,
+    err: RedDbErrorKind,
 }
 
 impl RedDbError {
     pub fn kind(&self) -> RedDbErrorKind {
-        *self.err.get_context()
+        self.err
     }
 }
 
 impl From<RedDbErrorKind> for RedDbError {
     fn from(kind: RedDbErrorKind) -> RedDbError {
         RedDbError {
-            err: Context::new(kind),
+            err: kind,
         }
-    }
-}
-
-impl From<Context<RedDbErrorKind>> for RedDbError {
-    fn from(err: Context<RedDbErrorKind>) -> RedDbError {
-        RedDbError { err }
-    }
-}
-
-impl Fail for RedDbError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.err.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.err.backtrace()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use std::fmt::{self, Display};
+use thiserror::Error;
 use uuid::Uuid;
 
 pub type Result<T> = ::anyhow::Result<T, RedDbError>;
@@ -58,9 +58,7 @@ impl RedDbError {
 
 impl From<RedDbErrorKind> for RedDbError {
     fn from(kind: RedDbErrorKind) -> RedDbError {
-        RedDbError {
-            err: kind,
-        }
+        RedDbError { err: kind }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use failure::ResultExt;
 use futures::stream::{self, StreamExt};
 use futures::TryStreamExt;
 use std::collections::HashMap;
@@ -126,7 +125,7 @@ where
         self.storage
             .persist(&[doc.to_owned()])
             .await
-            .context(RedDbErrorKind::Datapersist)?;
+            .map_err(|_| RedDbErrorKind::Datapersist)?;
         Ok(doc)
     }
 
@@ -142,7 +141,7 @@ where
         self.storage
             .persist(&docs)
             .await
-            .context(RedDbErrorKind::Datapersist)?;
+            .map_err(|_| RedDbErrorKind::Datapersist)?;
 
         Ok(docs)
     }
@@ -183,7 +182,7 @@ where
             self.storage
                 .persist(&[doc])
                 .await
-                .context(RedDbErrorKind::Datapersist)?;
+                .map_err(|_| RedDbErrorKind::Datapersist)?;
 
             Ok(true)
         } else {
@@ -278,7 +277,7 @@ where
         self.storage
             .persist(&docs)
             .await
-            .context(RedDbErrorKind::Datapersist)?;
+            .map_err(|_| RedDbErrorKind::Datapersist)?;
 
         Ok(result)
     }
@@ -297,7 +296,7 @@ where
         self.storage
             .persist(&docs)
             .await
-            .context(RedDbErrorKind::Datapersist)?;
+            .map_err(|_| RedDbErrorKind::Datapersist)?;
 
         Ok(docs.len())
     }
@@ -309,7 +308,7 @@ where
         Ok(self
             .serializer
             .serialize(value)
-            .context(RedDbErrorKind::Serialization)?)
+            .map_err(|_| RedDbErrorKind::Serialization)?)
     }
 
     fn deserialize<T>(&self, value: &[u8]) -> Result<T>
@@ -319,7 +318,7 @@ where
         Ok(self
             .serializer
             .deserialize(value)
-            .context(RedDbErrorKind::Deserialization)?)
+            .map_err(|_| RedDbErrorKind::Deserialization)?)
     }
 }
 

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Error};
+use anyhow::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -1,7 +1,6 @@
-use failure::Error;
+use anyhow::{Result, Error};
 use serde::{Deserialize, Serialize};
 use std::default::Default;
-use std::result::Result;
 
 mod bin;
 mod json;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use uuid::Uuid;
 
-type Result<T, E = Error> = std::result::Result<T, E>;
+type Result<T, E = Error> = anyhow::Result<T, E>;
 
 async fn setup() -> Result<()> {
     if Path::new(".db.yaml").exists() {


### PR DESCRIPTION
This solves issue #8

Maybe there is a better way then mapping the errors to the expected `RedDbErrorKind`?