### PR TITLE
Fix rustsec dirs next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ yaml_ser = ["serde_yaml"]
 #grcov ./target/debug/ -s . -t html --llvm --branch --ignore-not-existing -o ./target/debug/coverage/
 
 [dev-dependencies]
-grcov = "0.6.1"
+grcov = "0.8.2"
 tokio-test = "0.4.0"
 
 [dev-dependencies.cargo-husky]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ where
             .await
             .map_err(|_| RedDbErrorKind::PoisonedValue)?;
 
-        let data = data.get(&id).ok_or(RedDbErrorKind::NotFound { _id: *id })?;
+        let data = data.get(id).ok_or(RedDbErrorKind::NotFound { _id: *id })?;
 
         let data = self.deserialize(&*data)?;
         let doc = self.create_doc(id, data, Status::In);
@@ -173,7 +173,7 @@ where
 
         if data.contains_key(id) {
             let data = data
-                .get_mut(&id)
+                .get_mut(id)
                 .ok_or(RedDbErrorKind::NotFound { _id: *id })?;
 
             *data = self.serialize(&new_value)?;

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -153,7 +153,7 @@ where
             .await
             .map_err(|_| RedDbErrorKind::FlushData)?;
         storage
-            .write_all(&data)
+            .write_all(data)
             .await
             .map_err(|_| RedDbErrorKind::FlushData)?;
         storage
@@ -166,7 +166,7 @@ where
     async fn append(&self, data: &[u8]) -> Result<()> {
         let mut storage = self.db_file.lock().await;
         storage.seek(SeekFrom::End(0)).await.unwrap();
-        storage.write_all(&data).await.unwrap();
+        storage.write_all(data).await.unwrap();
         storage.sync_all().await.unwrap();
         Ok(())
     }


### PR DESCRIPTION
Fixes #7 
The dirs dependency was used in `simplelog` in the dev-dependency `grcov`. I bumped the version to latest and fixed the clippy errors.

EDIT: Clippy errors with stable should be fixed even if the CI has aborted. For nightly the warnings seem to be errors now but that could be fixed in main imho.